### PR TITLE
Fix for issue where listing files were lost when sync-html was run

### DIFF
--- a/src/markdoc/cli/commands.py
+++ b/src/markdoc/cli/commands.py
@@ -239,6 +239,8 @@ def sync_html(config, args):
     
     log.debug('rsync completed')
 
+    build_listing(config, args)
+
 
 ## Building
 


### PR DESCRIPTION
Build-listing needs to put the listing files directly into the HTML directory (instead of the temp directory) because of the static files (see line 107 in builder.py for more info on this). However, the sync-html command would overwrite the listing files. Since the internal workings of how build-listing works is not apparent to end users, I propose that build-listing is run after a sync-html command is run. This also makes sense because you have new data in the HTML directory, so you need new listing files. The attached patch does this.
