### PR TITLE
Multiple templates

### DIFF
--- a/doc/.markdoc.yaml
+++ b/doc/.markdoc.yaml
@@ -4,6 +4,15 @@ google-analytics: UA-9915287-4
 wiki-dir: "."
 static-dir: ".static"
 
+custom-templates:
+  -
+    regexps: ["/about.md","/tips/*.md" ]
+    template: "other1.html"
+  -
+    regexps: ["/index.md" ]
+    template: "index.html"
+
+
 markdown:
   extensions:
     - codehilite

--- a/doc/.markdoc.yaml
+++ b/doc/.markdoc.yaml
@@ -4,15 +4,6 @@ google-analytics: UA-9915287-4
 wiki-dir: "."
 static-dir: ".static"
 
-custom-templates:
-  -
-    regexps: ["/about.md","/tips/*.md" ]
-    template: "other1.html"
-  -
-    regexps: ["/index.md" ]
-    template: "index.html"
-
-
 markdown:
   extensions:
     - codehilite

--- a/doc/ref/configuration.md
+++ b/doc/ref/configuration.md
@@ -32,6 +32,15 @@ Markdoc’s behavior:
     listing-filename: "_list.html"
     use-default-static: true
     use-default-templates: true
+
+    # Custom templates
+    custom-templates:
+      -
+        regexps: ["about.md", "tips/.*" ]
+        template: "other-template.html"
+      -
+        regexps: ["index.md" ]
+        template: "index-template.html"
     
     # Rendering
     markdown:
@@ -121,6 +130,16 @@ is an acceptable value.
     [`rsync` documentation][rsync-docs].
 
   [rsync-docs]: http://www.samba.org/ftp/rsync/rsync.html
+
+### Custom templates
+
+A *optional* list of custom templates. Each item of the list defines:
+
+`regexps`
+:   A list of regexp to match files.
+
+`template`
+:   The template to use for the matching files.
 
 ### Building
 

--- a/doc/ref/configuration.md
+++ b/doc/ref/configuration.md
@@ -133,7 +133,9 @@ is an acceptable value.
 
 ### Custom templates
 
-A *optional* list of custom templates. Each item of the list defines:
+A *optional* list of custom templates used for override the default one.
+
+Each item of the list defines:
 
 `regexps`
 :   A list of regexp to match files.

--- a/src/markdoc/builder.py
+++ b/src/markdoc/builder.py
@@ -181,8 +181,15 @@ class Builder(object):
         context['title'] = self.title(path)
         context['crumbs'] = self.crumbs(path)
         context['make_relative'] = lambda href: make_relative(path, href)
+
+        template = 'document.html'
+        # custom templates
+        for item in self.config.get('custom-templates', []):
+            if (any(re.match(regexp, path) for regexp in item['regexps'])):
+                template = item['template']
+                break
         
-        template = self.config.template_env.get_template('document.html')
+        template = self.config.template_env.get_template(template)
         return template.render(context)
     
     def render_listing(self, path):

--- a/test/builder.doctest
+++ b/test/builder.doctest
@@ -42,6 +42,7 @@ You can also walk through all files in the wiki, using the `walk()` method:
     file1.md
     file2.md
     file3.md
+    custom/hello.md
     subdir/hello.md
 
 Rendering
@@ -117,3 +118,22 @@ You can render whole documents using `Builder.render_document()`:
     </html>
 
 This uses the `document.html` Jinja2 template, by default located in `WIKI_ROOT/.templates/`, to produce the documents.
+
+Custom templates
+----------------
+
+If the document has a custom template defined in the configuration, it's applied.
+
+    >>> print b.render_document('custom/hello.md')
+    <?xml version="1.0" encoding="utf-8"?>
+    <!DOCTYPE html>
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+      <title>Hello custom.</title>
+      <link rel="stylesheet" type="text/css" href="/other.css" />
+    </head>
+    <body>
+      <h1>Custom Template</h1>
+      <h1>Hello custom.</h1>
+    </body>
+    </html>

--- a/test/cli.doctest
+++ b/test/cli.doctest
@@ -14,6 +14,8 @@ The `show-config` command will show the current Markdoc config:
 
     >>> exit_code = markdoc('show-config') # doctest: +ELLIPSIS
     {'9d03e32c6cb1455388a170e3bb0c2030': '7010d5d5871143d089cb662cb540cbd5',
+     'custom-templates': [{'regexps': ['/wiki/custom/.*'],
+                           'template': 'custom-template.html'}],
      'hide-prefix': '_',
      'meta.config-file': '.../example/markdoc.yaml',
      'meta.root': '.../example',
@@ -43,6 +45,7 @@ There are three other commands -- `clean-html`, `clean-temp`, and `sync-html` --
     >>> print '\n'.join(sorted(os.listdir(CONFIG.html_dir)))
     _list.html
     an_empty_file.html
+    custom
     example.css
     file1.html
     file2.html

--- a/test/cli.doctest
+++ b/test/cli.doctest
@@ -14,7 +14,7 @@ The `show-config` command will show the current Markdoc config:
 
     >>> exit_code = markdoc('show-config') # doctest: +ELLIPSIS
     {'9d03e32c6cb1455388a170e3bb0c2030': '7010d5d5871143d089cb662cb540cbd5',
-     'custom-templates': [{'regexps': ['/wiki/custom/.*'],
+     'custom-templates': [{'regexps': ['custom/.*'],
                            'template': 'custom-template.html'}],
      'hide-prefix': '_',
      'meta.config-file': '.../example/markdoc.yaml',

--- a/test/example/_templates/custom-template.html
+++ b/test/example/_templates/custom-template.html
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+  <title>{{ title }}</title>
+  <link rel="stylesheet" type="text/css" href="/other.css" />
+</head>
+<body>
+  <h1>Custom Template</h1>
+  {{ content }}
+</body>
+</html>

--- a/test/example/markdoc.yaml
+++ b/test/example/markdoc.yaml
@@ -2,3 +2,8 @@ hide-prefix: "_"
 use-default-templates: no
 use-default-static: no
 9d03e32c6cb1455388a170e3bb0c2030: 7010d5d5871143d089cb662cb540cbd5
+
+custom-templates:
+  -
+    regexps: ["custom/.*" ]
+    template: "custom-template.html"

--- a/test/example/wiki/custom/hello.md
+++ b/test/example/wiki/custom/hello.md
@@ -1,0 +1,1 @@
+# Hello custom.

--- a/test/listing.doctest
+++ b/test/listing.doctest
@@ -13,6 +13,7 @@ The wiki should now be built in the HTML root:
     >>> print '\n'.join(os.listdir(CONFIG.html_dir))
     _list.html
     an_empty_file.html
+    custom
     example.css
     file1.html
     file2.html
@@ -60,7 +61,8 @@ Now we can get the listing for the HTML root itself, just by passing the empty s
                 'size': 254,
                 'slug': 'file2',
                 'title': u'World'}],
-     'sub_directories': [{'basename': 'subdir', 'href': '/subdir/'}]}
+     'sub_directories': [{'basename': 'custom', 'href': '/custom/'},
+                         {'basename': 'subdir', 'href': '/subdir/'}]}
 
 We can also get the listings for subdirectories, by passing in their paths, relative to the HTML root:
 


### PR DESCRIPTION
Allows to define different templates using regexps. The default template is used in case no matching regexp is found.

Example configuration:

```
# Custom templates
custom-templates:
   -
     regexps: ["about.md", "tips/.*" ]
     template: "other-template.html"
   -
     regexps: ["index.md" ]
     template: "index-template.html"
```
